### PR TITLE
Гуляев Дмитрий, 3530901/70201, lab2 dhcp server

### DIFF
--- a/dhcp_server.py
+++ b/dhcp_server.py
@@ -1,0 +1,150 @@
+import socket
+import argparse
+
+
+# DHCP message types
+DHCPDISCOVER = 1
+DHCPOFFER = 2
+DHCPREQUEST = 3
+DHCPDECLINE = 4
+DHCPACK = 5
+DHCPNAK = 6
+DHCPRELEASE = 7
+
+
+parser = argparse.ArgumentParser(description='DHCP server')
+parser.add_argument("--ip", default='0.0.0.0', type=str, help='ip address at wich server will receive messages')
+parser.add_argument("--port", default=67, type=int, help='port at wich server will receive messages')
+parser.add_argument("--mask", default='255.255.255.0', type=str, help='subnet mask')
+parser.add_argument("--router", default='192.168.0.1', type=str, help='router address')
+parser.add_argument("--domain", default='192.168.0.1', type=str, help='domain name server')
+parser.add_argument("-d", default=0, type=bool, help='show details: 1 to show all incoming and outcoming messages')
+args = parser.parse_args()
+host_address = args.ip
+server_port = args.port
+subnet_mask = args.mask
+router_address = args.router
+domain_name_server = args.domain
+show_details = args.d
+
+
+assigned_addresses = []
+
+
+# get address to offer/assign
+def get_yiaddr():
+    current_free_yiaddr = bytearray([int(byte) for byte in host_address.split('.')])
+    while current_free_yiaddr[3] <= 255:
+        current_free_yiaddr[3] = current_free_yiaddr[3] + 1
+        if current_free_yiaddr not in assigned_addresses:
+            return current_free_yiaddr
+
+
+
+class DHCPPacket:
+    def __init__(self):
+        self.op = bytearray([2])  # message type, 2 for reply
+        self.htype = bytearray([1])  # hardware address type, 1 for 10mb ethernet by default
+        self.hlen = bytearray([6])  # hardware address length, 6 for 10mb ethernet by default
+        self.hops = bytearray([0])  # used by relay agents, client sets to 0
+        self.xid = bytearray(4)  # transaction ID, random number chosen by client
+        self.secs = bytearray(2)  # seconds elapsed, filled in by client
+        self.flags = bytearray(2)  # flags from client's DHCPDISCOVER or DHCPREQUEST
+        self.ciaddr = bytearray(4)  # client's IP address
+        self.yiaddr = bytearray(4)  # available network address for client
+        self.siaddr = bytearray([0, 0, 0, 0])  # IP address of next server to use, 0.0.0.0 by default
+        self.giaddr = bytearray([0, 0, 0, 0])  # relay agent IP address, 0.0.0.0 by default
+        self.chaddr = bytearray(16)  # client hardware address
+        self.sname = bytearray(64)  # optional server host name
+        self.file = bytearray(128)  # boot file name, 0 by default
+        self.options = bytearray(312)
+        self.options[:4] = [99, 130, 83, 99]  # magic cookie
+        self.options[4:7] = [53, 1, 2]  # DHCP message type, option code 53, length 1, type 2 (DHCPOFFER) by default
+        self.options[7:13] = bytearray([54, 4]) + bytearray([int(byte) for byte in host_address.split('.')]) # DHCP server identifier, option code 54, length 4, server IP address
+        self.options[13:19] = [51, 4, 255, 255, 255, 255]  # IP address lease time, code 51, len 4, time in seconds (maximum by default)
+        self.options[19:25] = bytearray([1, 4]) + bytearray([int(byte) for byte in subnet_mask.split('.')]) # subnet mask, code 1, len 4, mask
+        self.options[25:31] = bytearray([3, 4]) + bytearray([int(byte) for byte in router_address.split('.')]) # router, code 3, len = 4 * number_of_routers, assuming only one router on subnet with default address 192.168.0.1
+        self.options[31:37] = bytearray([6, 4]) + bytearray([int(byte) for byte in domain_name_server.split('.')]) # domain name server, code 6, len = 4 * number_of_servers, assuming one server with default address 192.168.0.1 
+        self.options[37:38] = [255]  # end option, code 255, default len 1, subsequent options are pad options
+
+
+    # combine DHCP packet fields in one bytearray
+    def form_packet(self):
+        return self.op + self.htype + self.hlen + self.hops + self.xid + self.secs + self.flags + self.ciaddr + self.yiaddr \
+        + self.siaddr + self.giaddr + self.chaddr + self.sname + self.file + self.options
+
+
+# creating and binding UDP-socket
+print('DHCP server starting at', host_address,':', server_port)
+server_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+server_socket.bind((host_address, server_port))
+
+
+# get DHCP reply packet depending on incoming DHCP message type
+def get_dhcp_packet(msg):
+    packet = DHCPPacket()
+
+    packet.xid = msg[4:8]
+    print('extracted xid: ', packet.xid)
+    packet.flags = msg[10:12]
+    print('extracted flags: ', packet.flags)
+    packet.ciaddr = msg[12:16]
+    print('extracted ciaddr: ', packet.ciaddr)
+    packet.giaddr = msg[24:28]
+    print('extracted giaddr: ', packet.giaddr)
+    packet.chaddr = msg[28:44]
+    print('extracted chaddr: ', packet.chaddr)
+
+    # check for requested address option field
+    if msg[243] == 50 and msg[245:249] != bytearray([0, 0, 0, 0]) and msg[245:249] not in assigned_addresses:
+        packet.yiaddr = msg[245:249]
+    else:
+        packet.yiaddr = get_yiaddr()
+
+    if msg[242] == DHCPDISCOVER:
+        packet.options[6] = 2  # DHCPOFFER
+        print('offered yiaddr: ', [int(byte) for byte in packet.yiaddr])
+
+    if msg[242] == DHCPREQUEST:
+        packet.options[6] = 5  # DHCPACK
+        assigned_addresses.append(packet.yiaddr)
+        print('yiaddr to assign: ', [int(byte) for byte in packet.yiaddr])
+  
+    return packet.form_packet()
+
+
+while True:
+    msg, addr = server_socket.recvfrom(1024)
+
+    if show_details:
+        print('INCOMING MESSAGE:')
+        print([byte for byte in msg])
+
+    print('MESSAGE RECEIVED FROM: ', addr)
+    print('MESSAGE TYPE:', msg[242])
+
+    if msg[242] == DHCPDISCOVER or msg[242] == DHCPREQUEST:
+
+        if msg[242] == DHCPDISCOVER:
+            print('DHCPDISCOVER ACCEPTED')
+            print('SENDING DHCPOFFER TO ', addr)
+            
+        elif msg[242] == DHCPREQUEST:
+            print('DHCPREQUEST ACCEPTED')
+            print('SENDING DHCPACK TO ', addr)
+
+        reply = get_dhcp_packet(msg)
+        server_socket.sendto(reply, addr)
+
+        if show_details:
+            print('OUTCOMING MESSAGE:')
+            print([byte for byte in reply])
+
+    if msg[242] == DHCPDECLINE:
+        print('DHCPDECLINE ACCEPTED')
+        print('possible configuration problem')
+
+    if msg[242] == DHCPRELEASE:
+        print('DHCPRELEASE ACCEPTED')
+        assigned_addresses.remove(msg[12:16])  # removing client address from assigned addresses  
+        print([byte for byte in msg[12:16]], 'removed from assigned addresses')   


### PR DESCRIPTION
### Инструкция по использованию
Запустить скрипт командой `python3 dhcp_server.py` с нужными аргументами. Для использования порта 67 необходимо запускать программу с правами суперпользователя: `sudo python3 dhcp_server.py`. Возможные аргументы:
```
  -h, --help       show this help message and exit
  --ip IP          ip address at wich server will receive messages
  --port PORT      port at wich server will receive messages
  --mask MASK      subnet mask
  --router ROUTER  router address
  --domain DOMAIN  domain name server
  -d D             show details: 1 to show all incoming and outcoming messages
```
По дефолту сервер запускается по адресу 0.0.0.0, порт 67.

### Описание используемого протокола.
Структура DHCP-сообщения, в скобках указана длина поля в октетах (байтах):
```
   0               1               2               3
   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
   |     op (1)    |   htype (1)   |   hlen (1)    |   hops (1)    |
   +---------------+---------------+---------------+---------------+
   |                            xid (4)                            |
   +-------------------------------+-------------------------------+
   |           secs (2)            |           flags (2)           |
   +-------------------------------+-------------------------------+
   |                          ciaddr  (4)                          |
   +---------------------------------------------------------------+
   |                          yiaddr  (4)                          |
   +---------------------------------------------------------------+
   |                          siaddr  (4)                          |
   +---------------------------------------------------------------+
   |                          giaddr  (4)                          |
   +---------------------------------------------------------------+
   |                                                               |
   |                          chaddr  (16)                         |
   |                                                               |
   |                                                               |
   +---------------------------------------------------------------+
   |                                                               |
   |                          sname   (64)                         |
   +---------------------------------------------------------------+
   |                                                               |
   |                          file    (128)                        |
   +---------------------------------------------------------------+
   |                                                               |
   |                          options (variable)                   |
   +---------------------------------------------------------------+
```
```
   FIELD      OCTETS       DESCRIPTION
   -----      ------       -----------

   op            1  Message op code / message type.
                    1 = BOOTREQUEST, 2 = BOOTREPLY
   htype         1  Hardware address type, see ARP section in "Assigned
                    Numbers" RFC; e.g., '1' = 10mb ethernet.
   hlen          1  Hardware address length (e.g.  '6' for 10mb
                    ethernet).
   hops          1  Client sets to zero, optionally used by relay agents
                    when booting via a relay agent.
   xid           4  Transaction ID, a random number chosen by the
                    client, used by the client and server to associate
                    messages and responses between a client and a
                    server.
   secs          2  Filled in by client, seconds elapsed since client
                    began address acquisition or renewal process.
   flags         2  Flags (see figure 2).
   ciaddr        4  Client IP address; only filled in if client is in
                    BOUND, RENEW or REBINDING state and can respond
                    to ARP requests.
   yiaddr        4  'your' (client) IP address.
   siaddr        4  IP address of next server to use in bootstrap;
                    returned in DHCPOFFER, DHCPACK by server.
   giaddr        4  Relay agent IP address, used in booting via a
                    relay agent.
   chaddr       16  Client hardware address.
   sname        64  Optional server host name, null terminated string.
   file        128  Boot file name, null terminated string; "generic"
                    name or null in DHCPDISCOVER, fully qualified
                    directory-path name in DHCPOFFER.
   options     var  Optional parameters field.  See the options
                    documents for a list of defined options.
```
В данной программе поля sname и file не заполняются. При приеме и отправке сообщений используются следующие опции (помимо pad option, end option и magic cookie):
Subnet Mask:
```
    Code   Len        Subnet Mask
   +-----+-----+-----+-----+-----+-----+
   |  1  |  4  |  m1 |  m2 |  m3 |  m4 |
   +-----+-----+-----+-----+-----+-----+

```
Router Option:
```

    Code   Len         Address 1               Address 2
   +-----+-----+-----+-----+-----+-----+-----+-----+--
   |  3  |  n  |  a1 |  a2 |  a3 |  a4 |  a1 |  a2 |  ...
   +-----+-----+-----+-----+-----+-----+-----+-----+--
```
Domain Name Server Option:
```
    Code   Len         Address 1               Address 2
   +-----+-----+-----+-----+-----+-----+-----+-----+--
   |  6  |  n  |  a1 |  a2 |  a3 |  a4 |  a1 |  a2 |  ...
   +-----+-----+-----+-----+-----+-----+-----+-----+--
```
DHCP Message Type:
```

           Value   Message Type
           -----   ------------
             1     DHCPDISCOVER
             2     DHCPOFFER
             3     DHCPREQUEST
             4     DHCPDECLINE
             5     DHCPACK
             6     DHCPNAK
             7     DHCPRELEASE

    Code   Len  Type
   +-----+-----+-----+
   |  53 |  1  | 1-7 |
   +-----+-----+-----+
```
Server Identifier:
```
    Code   Len            Address
   +-----+-----+-----+-----+-----+-----+
   |  54 |  4  |  a1 |  a2 |  a3 |  a4 |
   +-----+-----+-----+-----+-----+-----+
```
IP Address Lease Time:
```

    Code   Len         Lease Time
   +-----+-----+-----+-----+-----+-----+
   |  51 |  4  |  t1 |  t2 |  t3 |  t4 |
   +-----+-----+-----+-----+-----+-----+
```
Requested IP Address:
```
    Code   Len          Address
   +-----+-----+-----+-----+-----+-----+
   |  50 |  4  |  a1 |  a2 |  a3 |  a4 |
   +-----+-----+-----+-----+-----+-----+
```
Данные опции были выбраны исходя из того, с какими опциями ходят пакеты у меня по сети на машине с ubuntu 20. Подразумевается использование только одного роутера и одного сервера имен. Важным моментом является то, что механизм аренды адресов реализован тривиально, не по RFC-стандарту. Предлагаемый/назначаемый адрес отсчитывается от адреса сервера, назначенные адреса хранятся в простом массиве, адрес выдается на максимальное время. Можно было бы создать базу данных и реализовать аренду по всем правилам стандарта, но мне показалось, что это уже выходит за рамки курса. Может быть, я был неправ.
Сервер умеет принимать сообщения типа DHCPDISCOVER, DHCPREQUEST, DHCPRELEASE и DHCPDECLINE и отвечать DHCPOFFER и DHCPACK.
Сервер проверялся в основном работой с клиентом dhclient. С проверкой сервера возникли некоторые трудности. Например, DHCPDISCOVER от клиента dhclient не воспринимался сервером, хотя все сообщения DHCPREQUEST приходили. Для проверки работы с DHCPDISCOVER потребовалось использовать утилиту nmap:
`sudo nmap --script broadcast-dhcp-discover`
Вывод утилиты:
```
| broadcast-dhcp-discover: 
|   Response 1 of 1: 
|     IP Offered: 192.168.0.103
|     DHCP Message Type: DHCPOFFER
|     Server Identifier: 192.168.0.1
|     IP Address Lease Time: 2h00m00s
|     Subnet Mask: 255.255.255.0
|     Router: 192.168.0.1
|_    Domain Name Server: 192.168.0.1
```
Здесь видно, что предложение поступило от стандартного сервера, а не от моего, хотя сервер реагирует и отправляет сообщение по соответствующему адресу:
```
DHCP server starting at 0.0.0.0 : 67
MESSAGE RECEIVED FROM:  ('192.168.0.104', 68)
MESSAGE TYPE: 1
DHCPDISCOVER ACCEPTED
SENDING DHCPOFFER TO  ('192.168.0.104', 68)
extracted xid:  b'l\x1c\xf5\t'
extracted flags:  b'\x80\x00'
extracted ciaddr:  b'\x00\x00\x00\x00'
extracted giaddr:  b'\x00\x00\x00\x00'
extracted chaddr:  b'\xde\xad\xc0\xde\xca\xfe\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
offered yiaddr:  [0, 0, 0, 1]
```
Для проверки DHCPREQUEST можно использовать dhclient, но ситуация примерно та же:
`sudo dhclient -s 0.0.0.0 -v`
Вывод dhclient:
```
Listening on LPF/wlp3s0/6c:71:d9:56:cf:93
Sending on   LPF/wlp3s0/6c:71:d9:56:cf:93
Listening on LPF/enp4s0/60:a4:4c:72:5b:2c
Sending on   LPF/enp4s0/60:a4:4c:72:5b:2c
Sending on   Socket/fallback
DHCPREQUEST for 192.168.0.104 on wlp3s0 to 0.0.0.0 port 67 (xid=0x35243577)
DHCPDISCOVER on enp4s0 to 0.0.0.0 port 67 interval 3 (xid=0xa7a118)
```
 Реакция сервера:
```
MESSAGE RECEIVED FROM:  ('127.0.0.1', 68)
MESSAGE TYPE: 3
DHCPREQUEST ACCEPTED
SENDING DHCPACK TO  ('127.0.0.1', 68)
extracted xid:  b'w5$5'
extracted flags:  b'\x00\x00'
extracted ciaddr:  b'\x00\x00\x00\x00'
extracted giaddr:  b'\x00\x00\x00\x00'
extracted chaddr:  b'lq\xd9V\xcf\x93\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
yiaddr to assign:  [192, 168, 0, 104]
```
Здесь назначаемый адрес был взят из поля Requested IP Address опций поступившего DHCPREQUEST.